### PR TITLE
Fix interview-prep notebooks for GitHub preview rendering.

### DIFF
--- a/interview-prep/basic_datastructure.ipynb
+++ b/interview-prep/basic_datastructure.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d371449c",
    "metadata": {},
    "source": [
     "## LRU CACHE\n",
@@ -15,7 +14,6 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "fe225b50",
    "metadata": {},
    "outputs": [
     {
@@ -93,7 +91,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "677c2110",
    "metadata": {},
    "source": [
     "## Top K Frequent Elements\n",
@@ -107,7 +104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15201b54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +135,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7dcbeb8",
    "metadata": {},
    "source": [
     "## Merge Intervals\n",
@@ -159,7 +154,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e81fd5c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +172,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4aaa7748",
    "metadata": {},
    "source": [
     "## Transaction Fraud Window -  Sliding Window\n",
@@ -199,7 +192,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "264965c6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +218,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1ea9d14",
    "metadata": {},
    "source": [
     "## Rate Limiter\n",
@@ -240,7 +231,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58cb6c97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,5 +273,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }

--- a/interview-prep/senior-ai-engineer.ipynb
+++ b/interview-prep/senior-ai-engineer.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d057bfa2",
    "metadata": {},
    "source": [
     "## Embedding Similarity\n",
@@ -12,7 +11,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe2297e2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +49,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62a2f82d",
    "metadata": {},
    "source": [
     "## Chunking Strategy\n",
@@ -62,7 +59,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc29ef77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +95,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed219cb8",
    "metadata": {},
    "source": [
     "## Retrieval Pipeline\n",
@@ -109,7 +104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e633cbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,5 +211,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
Downgrade nbformat to 4.4 and remove cell ids so GitHub's notebook viewer can render the files.

## Summary
What does this PR change?

## Type
- [ ] Feature / new notebook / new demo
- [ x] Bug fix
- [ ] Documentation / README
- [ ] Refactor / cleanup
- [ ] Tooling / automation

## File/Notebook paths touched
List key files (example: `demo_applications/...`)

## Why this change?
Explain the reason/value in 2–4 lines.

## How to test / validate
Steps to verify it works:
1.
2.

## Checklist
- [x ] I ran the notebook / code successfully
- [ x] I added/updated README links if needed
- [ x] I included screenshots/output where useful
- [ x] No secrets/keys are committed
