### PR TITLE
Fix interview-prep notebooks for GitHub preview rendering.

### DIFF
--- a/interview-prep/basic_datastructure.ipynb
+++ b/interview-prep/basic_datastructure.ipynb
@@ -13,22 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "None\n",
-      "None\n",
-      "1\n",
-      "None\n",
-      "2\n",
-      "None\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "class Node:\n",
     "    def __init__(self, k=0, v=0):\n",
@@ -255,7 +242,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -273,5 +260,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/interview-prep/senior-ai-engineer.ipynb
+++ b/interview-prep/senior-ai-engineer.ipynb
@@ -201,15 +201,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.9.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }


### PR DESCRIPTION
Use nbformat 4.2, clear cell outputs, and standardize notebook metadata to match notebooks that render correctly on GitHub.

## Summary
What does this PR change?

## Type
- [ ] Feature / new notebook / new demo
- [ ] Bug fix
- [ ] Documentation / README
- [ ] Refactor / cleanup
- [ ] Tooling / automation

## File/Notebook paths touched
List key files (example: `demo_applications/...`)

## Why this change?
Explain the reason/value in 2–4 lines.

## How to test / validate
Steps to verify it works:
1.
2.

## Checklist
- [ ] I ran the notebook / code successfully
- [ ] I added/updated README links if needed
- [ ] I included screenshots/output where useful
- [ ] No secrets/keys are committed
