### PR TITLE
Fix interview-prep notebook GitHub preview and add nbviewer links.

### DIFF
--- a/interview-prep/README.md
+++ b/interview-prep/README.md
@@ -1,0 +1,20 @@
+# Interview Prep
+
+Coding drills and AI-engineering practice notebooks.
+
+## Notebooks
+
+GitHub's built-in `.ipynb` preview sometimes shows **"Notebook not found"** (GitHub renderer issue).  
+Use **nbviewer** to read them in the browser:
+
+| Notebook | nbviewer |
+|----------|----------|
+| [basic_datastructure.ipynb](basic_datastructure.ipynb) | [Open in nbviewer](https://nbviewer.org/github/05satyam/AI-ML/blob/main/interview-prep/basic_datastructure.ipynb) |
+| [senior-ai-engineer.ipynb](senior-ai-engineer.ipynb) | [Open in nbviewer](https://nbviewer.org/github/05satyam/AI-ML/blob/main/interview-prep/senior-ai-engineer.ipynb) |
+
+Or open locally in VS Code / Jupyter.
+
+## Topics
+
+- `basic_datastructure.ipynb` — LRU cache, top-K, merge intervals, sliding window, rate limiter
+- `senior-ai-engineer.ipynb` — embeddings, TF-IDF, chunking, RAG retrieval pipeline

--- a/interview-prep/basic_datastructure.ipynb
+++ b/interview-prep/basic_datastructure.ipynb
@@ -109,15 +109,7 @@
     "        heapq.heappush(heap, (freq, num))\n",
     "        if len(heap) > k:\n",
     "            heapq.heappop(heap)\n",
-    "    return [num for freq, num in heap]\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n",
-    "\n"
+    "    return [num for freq, num in heap]\n"
    ]
   },
   {
@@ -153,8 +145,7 @@
     "        else:\n",
     "            merged[-1][1] = max(items[1], merged[-1][1])\n",
     "    \n",
-    "    return merged\n",
-    "    "
+    "    return merged\n"
    ]
   },
   {
@@ -199,8 +190,7 @@
     "        if len(q) > 3 :\n",
     "            flagged.append(user)\n",
     "    \n",
-    "    return flagged    \n",
-    "        "
+    "    return flagged    \n"
    ]
   },
   {
@@ -247,18 +237,10 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
    "version": "3.9.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/interview-prep/senior-ai-engineer.ipynb
+++ b/interview-prep/senior-ai-engineer.ipynb
@@ -43,8 +43,7 @@
     "                \"text\": docs[\"text\"],\n",
     "                \"score\": score\n",
     "            } for score, docs in scored_docs[:k]\n",
-    "        ]\n",
-    "    \n"
+    "        ]\n"
    ]
   },
   {
@@ -89,8 +88,7 @@
     "    \n",
     "    return chunks\n",
     "\n",
-    "    return chunks\n",
-    "    "
+    "    return chunks\n"
    ]
   },
   {
@@ -191,11 +189,7 @@
     "        \"text\": \"This is a test document.\"\n",
     "    }\n",
     "]\n",
-    "srp = SimpleRagPipeline(documents)\n",
-    "\n",
-    "\n",
-    "\n",
-    "        "
+    "srp = SimpleRagPipeline(documents)\n"
    ]
   }
  ],
@@ -206,18 +200,10 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
    "version": "3.9.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
Rebuild notebooks as nbformat 4.0 and re-add files to bust GitHub render cache. Document nbviewer fallback since GitHub's renderer returns Notebook not found for this repo.

## Summary
What does this PR change?

## Type
- [ ] Feature / new notebook / new demo
- [ x] Bug fix
- [ ] Documentation / README
- [ ] Refactor / cleanup
- [ ] Tooling / automation

## File/Notebook paths touched
List key files (example: `demo_applications/...`)

## Why this change?
Explain the reason/value in 2–4 lines.

## How to test / validate
Steps to verify it works:
1.
2.

## Checklist
- [ x] I ran the notebook / code successfully
- [ x] I added/updated README links if needed
- [ x] I included screenshots/output where useful
- [ x] No secrets/keys are committed
